### PR TITLE
添加了替换自定义字体的基本步骤说明

### DIFF
--- a/src/主题.md
+++ b/src/主题.md
@@ -100,6 +100,52 @@ Trilium还允许您创建不与主题关联的自定义CSS。这在[脚本编写
 
 您还可以为给定的笔记类型（和mime类型）创建特定的样式。例如，包含PNG图像的文件笔记将在树中具有以下类：`type-image mime-image-png`。
 
+## 替换自定义字体
+
+Trilium中可以轻松地替换自定义的字体，只需要将你喜欢的字体导入到只Trilium中，再匹配相应的CSS描述即可完成替换。需要注意的是，字体和主题是对应的，如果想要在不更换主题的情况下替换字体，只能通过修改该主题相关代码的方式进行修改。
+
+下面以官方提供的Steel Blue主题替换落霞文楷字体为例，说明基本的操作步骤：
+
+1. 下载落霞文楷字体：LXGWWenKai-Regular.ttf
+2. Trilium支持的字体文件格式为woff2，所以需要先将下载好的LXGWWenKai-Regular.ttf转换为woff2格式
+3. 复制官方Steel Blue笔记为my Steel Blue，并修改属性 appTheme的值为my-Steel-Blue
+4. 右键点击笔记 my Steel Blue，将LXGWWenKai-Regular.woff2文件导入其中
+5. 添加 LXGWWenKai-Regular.woff2 的属性，#customResourceProvider="fonts/LXGWWenKai-regular.woff2" 
+6. 修改 my Steel Blue 中第10行到40行的代码如下：
+    ```
+    @font-face {
+        font-family: 'LXGW WenKai';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src:
+            local('LXGW WenKai'),
+            url('../../../custom/fonts/LXGWWenKai-regular.woff2') format('woff2');
+    }
+
+    @font-face { /* This will be used as text content font (see below) */
+    font-family: 'Garamond';
+    font-style: normal;
+    font-weight: 400;
+    src: url('../../../custom/fonts/garamond.woff2') format('woff2');
+    }
+
+    :root {
+        --theme-style: light;
+        
+        --main-font-family: 'LXGW WenKai';
+        --main-font-size: normal;
+        
+        --tree-font-family: 'LXGW WenKai';
+        --tree-font-size: normal;
+        
+        --detail-font-family: 'LXGW WenKai';
+        --detail-font-size: normal;
+        
+        --monospace-font-family: 'Monospace';
+        --monospace-font-size: normal;
+    ```
+7. 前往Trilium设置中，切换主题为 my-Steel-Blue，重新加载即可成功替换字体
 ## 用户提供的主题
 
 以下是Trilium用户开发的主题：


### PR DESCRIPTION
添加了基于官方主题 steel blue，替换自定义字体的基本操作步骤。

方便初学者，以及不熟悉CSS代码的用户也可以按照流程自行替换字体。